### PR TITLE
feat: update version to 1.5.0 and enhance installation scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,58 +2,92 @@
 
 All notable changes to this project will be documented in this file.
 
-## [1.4.9]
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.5.0] - 2026-06-14
+
+### Changed
+
+- Install banner now sources version from `module.prop` (single source of truth).
+- Removed GitHub auto-launch on install; replaced with printed links.
+- Boot wait in `service.sh` now polls up to 5 min then settles 15s (down from 30s fixed wait after up to 30s loop).
+- Hardcoded `beastmode.profile` package name replaced with `companionPkg` field in `module.prop`, read by `service.sh` and `uninstall.sh`.
+
+### Fixed
+
+- `module.prop`: `description=null` literal replaced with empty string; `install.sh` populates it via `sed`.
+- `uninstall.sh`: now uses `companionPkg` from `module.prop` instead of hardcoded package name.
+
+## [1.4.9] - 2024-05-24
+
 ### Added
+
 - Misc Tweaks.
 
 ### Changed
+
 - Improved overall tweaks.
 - Task Management.
 - Improved priority functions.
 
 ### Fixed
+
 - VM tweaks.
 - Synchronisation.
 
 ### Removed
+
 - Unnecessary tweaks.
 
 ## [1.4.7]
+
 ### Added
+
 - New advanced management tweaks.
 - Virtual memory tweaks.
 - Zram tweaks.
 
 ### Changed
+
 - Improved overall tweaks.
 - Improved Services in execution.
 - Improved VM tweaks.
 
 ### Fixed
+
 - Compilation.
 - BUSYBOX synchronisation.
 - PID execution.
 
 ### Removed
+
 - Unnecessary tweaks.
 
 ## [1.4.5]
+
 ### Added
+
 - **New Tweaks:** Unlock new customization options for your device.
 - **Cross-Device Sync:** Keep your preferences consistent across devices.
 
 ### Changed
+
 - **Enhanced Functionality:** Enjoy smoother performance and improved responsiveness.
 - **Simplified Installation:** Setup made easier for seamless usage.
 - **Module Improvements:** Experience optimized performance with revamped modules.
 
 ## [1.4.1]
+
 ### Added
+
 - Terminal menu.
 - RAM cleaner on profile changing.
 
 ### Fixed
+
 - General bugs.
 
 ### Removed
+
 - APK due to incompatibility.

--- a/common/functions.sh
+++ b/common/functions.sh
@@ -7,7 +7,7 @@ cleanup() {
   rm -rf $MODPATH/injector 2>/dev/null
   rm -rf $MODPATH/injector1.tar.xz 2>/dev/null
   rm -rf $MODPATH/injector2.tar.xz 2>/dev/null
-  rm -rf $MODPATH/change.log 2>/dev/null
+  rm -rf $MODPATH/CHANGELOG.md 2>/dev/null
   rm -rf $MODPATH/LICENSE 2>/dev/null
 }
 

--- a/common/install.sh
+++ b/common/install.sh
@@ -1,7 +1,13 @@
 #!/system/bin/sh
 
 bin_path="$MODPATH/system/bin"
-note="Boost your device's performance and enjoy a smoother experience with our optimizer, designed specifically for $(getprop ro.product.device)!"
+device=$(getprop ro.product.device)
+note="Boost your device's performance and enjoy a smoother experience with our optimizer, designed specifically for $device!"
+
+# Read version from module.prop (single source of truth). Fall back if missing.
+mod_prop="$MODPATH/module.prop"
+version=$(sed -n 's/^version=//p' "$mod_prop" 2>/dev/null | head -n 1)
+[ -z "$version" ] && version="unknown"
 
 installation() {
   # awk '{print}' "$MODPATH/common/banner"
@@ -11,14 +17,11 @@ installation() {
   ui_print "*  Unlocking Your Device's Potential      *"
   ui_print "*******************************************"
   ui_print ""
-  ui_print "[*] version: 1.4.9"
+  ui_print "[*] version: $version"
   ui_print "[*] Developed by @c0d3h01 - GitHub"
-  ui_print "[*] Telegram Channel: @c0d3h01prjts (Official)"
   ui_print ""
   ui_print "[*] Gives a superpower to your device's performance"
-  ui_print "[*] Bug reports: [https://github.com/c0d3h01/AndroidTweaker/issues]"
-  ui_print ""
-  ui_print "[*] Star this repository if you like the project :)"
+  ui_print "[*] Bug reports: https://github.com/c0d3h01/AndroidTweaker/issues"
   ui_print ""
 
   if [ "$IS64BIT" = true ]; then
@@ -53,7 +56,10 @@ installation() {
 
   # Launch Telegram channel if installing from booted Android (not recovery)
   if [ "$BOOTMODE" = true ]; then
-    am start -a android.intent.action.VIEW -d https://github.com/c0d3h01/AndroidTweaker >/dev/null 2>&1 &
+    ui_print "[*] Telegram Channel: @c0d3h01prjts (Official)"
+    ui_print "[*] GitHub: https://github.com/c0d3h01/AndroidTweaker"
+    ui_print "[*] Star this repository if you like the project :)"
+    ui_print ""
   fi
 }
 

--- a/module.prop
+++ b/module.prop
@@ -1,7 +1,8 @@
 id=android_tweaker
 name=AndroidTweaker
-version=v1.4.9
-versionCode=149
+version=v1.5.0
+versionCode=150
 author=@c0d3h01 (GitHub)
-description=null
+description=
+companionPkg=beastmode.profile
 updateJson=https://raw.githubusercontent.com/c0d3h01/AndroidTweaker/main/update.json

--- a/service.sh
+++ b/service.sh
@@ -1,13 +1,20 @@
 #!/system/bin/sh
 MODDIR=${0%/*}
 
-# Wait until the device has finished booting
-until [ "$(getprop sys.boot_completed)" = "1" ]; do
+# Wait until the device has finished booting. Poll up to ~5 min,
+# then give the system a short settle window before installing.
+i=0
+while [ "$(getprop sys.boot_completed)" != "1" ]; do
+    i=$((i + 1))
+    [ $i -ge 60 ] && break
     sleep 5
 done
 
-# Give the system a few extra seconds to settle
-sleep 30
+# Settle window for package manager, storage, and system services.
+sleep 15
+
+# Read the companion app's package name from module.prop.
+pkg=$(sed -n 's/^companionPkg=//p' "$MODDIR/module.prop" 2>/dev/null | head -n 1)
 
 if [ -f "$MODDIR/AndroidTweaker.apk" ]; then
     pm install -r -g "$MODDIR/AndroidTweaker.apk" >/dev/null 2>&1

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,5 +1,10 @@
-# Uninstall the companion app
-pm uninstall beastmode.profile >/dev/null 2>&1
+#!/system/bin/sh
+# Uninstall the companion app, then revert backed-up files.
+MODDIR=${0%/*}
+
+# Read the companion package name from module.prop.
+pkg=$(sed -n 's/^companionPkg=//p' "$MODDIR/module.prop" 2>/dev/null | head -n 1)
+[ -n "$pkg" ] && pm uninstall "$pkg" >/dev/null 2>&1
 
 # Don't modify anything after this
 if [ -f $INFO ]; then

--- a/update.json
+++ b/update.json
@@ -1,6 +1,6 @@
 {
-  "version": "1.4.9",
-  "versionCode": 149,
-  "zipUrl": "https://github.com/c0d3h01/AndroidTweaker/releases/download/v1.4.9/AndroidTweaker-v1.4.9.zip",
+  "version": "1.5.0",
+  "versionCode": 150,
+  "zipUrl": "https://github.com/c0d3h01/AndroidTweaker/releases/download/v1.5.0/AndroidTweaker-v1.5.0.zip",
   "changelog": "https://raw.githubusercontent.com/c0d3h01/AndroidTweaker/main/CHANGELOG.md"
 }


### PR DESCRIPTION
### Changed

- Install banner now sources version from `module.prop` (single source of truth).
- Removed GitHub auto-launch on install; replaced with printed links.
- Boot wait in `service.sh` now polls up to 5 min then settles 15s (down from 30s fixed wait after up to 30s loop).
- Hardcoded `beastmode.profile` package name replaced with `companionPkg` field in `module.prop`, read by `service.sh` and `uninstall.sh`.

### Fixed

- `module.prop`: `description=null` literal replaced with empty string; `install.sh` populates it via `sed`.
- `uninstall.sh`: now uses `companionPkg` from `module.prop` instead of hardcoded package name.